### PR TITLE
Updated to work with https://github.com/joshmarshall/jsonrpclib

### DIFF
--- a/txjsonrpc/web/jsonrpc.py
+++ b/txjsonrpc/web/jsonrpc.py
@@ -92,7 +92,7 @@ class JSONRPC(resource.Resource, BaseSubhandler):
         content = request.content.read()
         parsed = jsonrpclib.loads(content)
         functionPath = parsed.get("method")
-        args = parsed.get('params')
+        args = parsed.get('params', [])
         id = parsed.get('id')
         version = parsed.get('jsonrpc')
         if version:


### PR DESCRIPTION
When using jsonrpclib with version 1.0, jsonrpclib does not send 'params' in request if there are no method parameters causing args to be None.

This change gives a default empty list for args.
