### PR TITLE
added @with_request decorator to receive the request object as the first parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ nohup.out
 *.sw[po]
 .venv-*
 .tx*-venv
+.idea
 =======
 debian/files
 debian/*.log

--- a/txjsonrpc/web/jsonrpc.py
+++ b/txjsonrpc/web/jsonrpc.py
@@ -30,6 +30,14 @@ Boolean = xmlrpclib.Boolean
 DateTime = xmlrpclib.DateTime
 
 
+def with_request(method):
+    """
+    Decorator to enable the request to be passed as the first argument.
+    """
+    method.with_request = True
+    return method
+
+
 class NoSuchFunction(Fault):
     """
     There is no function by the given name.
@@ -121,6 +129,10 @@ class JSONRPC(resource.Resource, BaseSubhandler):
                 request.setHeader("content-type", "application/json")
             else:
                 request.setHeader("content-type", "text/javascript")
+
+            if hasattr(function, 'with_request'):
+                args = [request] + args
+
             d = defer.maybeDeferred(function, *args, **kwargs)
             d.addErrback(self._ebRender, id)
             d.addCallback(self._cbRender, request, id, version)


### PR DESCRIPTION
This PR adds a decorator `@with_request` which can be placed before service methods in order to receive the current request object as the first parameter.

This decorator is known from the XMLRPC module and should be available for JSONRPC as well

Example:

```python
def jsonrpc_method_without_request(self, arg1, arg2):
    ...

@with_request
def jsonrpc_method_with_request(self, request, arg1, arg2):
    ...
```