### PR TITLE
preserve the original result of deferreds

### DIFF
--- a/txjsonrpc/web/jsonrpc.py
+++ b/txjsonrpc/web/jsonrpc.py
@@ -121,7 +121,8 @@ class JSONRPC(resource.Resource, BaseSubhandler):
             d.addCallback(self._cbRender, request, id, version)
         return server.NOT_DONE_YET
 
-    def _cbRender(self, result, request, id, version):
+    def _cbRender(self, original_result, request, id, version):
+        result = original_result
         if isinstance(result, Handler):
             result = result.result
         if version == jsonrpclib.VERSION_PRE1:
@@ -136,6 +137,7 @@ class JSONRPC(resource.Resource, BaseSubhandler):
         request.setHeader("content-length", str(len(s)))
         request.write(s)
         request.finish()
+        return original_result
 
     def _ebRender(self, failure, id):
         if isinstance(failure.value, jsonrpclib.Fault):


### PR DESCRIPTION
Then render callback was modified to returned the original result.
Returning the same deferred does not discard its value which helps to be able to cache deferreds on the server side.